### PR TITLE
Add setup.py for easier install

### DIFF
--- a/pelican_bibtex.py
+++ b/pelican_bibtex.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 from pelican import signals
 
+__version__ = '0.1'
+
 
 def add_publications(generator):
     """

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ Operating System :: Unix
 
 setup(
     name='pelican_bibtex',
-    description='A module for estimating Hemodynamical Response Function from functional MRI data',
+    description='Manage your academic publications page with Pelican and BibTeX',
     long_description=open('Readme.md').read(),
     version=pelican_bibtex.__version__,
     author='Vlad Niculae',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+import pelican_bibtex
+from distutils.core import setup
+
+CLASSIFIERS = """\
+Development Status :: 5 - Production/Stable
+Intended Audience :: Science/Research
+Intended Audience :: Developers
+License :: OSI Approved
+Programming Language :: Python
+Programming Language :: Python :: 3
+Topic :: Software Development
+Operating System :: POSIX
+Operating System :: Unix
+
+"""
+
+setup(
+    name='pelican_bibtex',
+    description='A module for estimating Hemodynamical Response Function from functional MRI data',
+    long_description=open('Readme.md').read(),
+    version=pelican_bibtex.__version__,
+    author='Vlad Niculae',
+    author_email='vlad@vene.ro',
+    url='https://pypi.python.org/pypi/pelican_bibtex',
+    py_modules=['pelican_bibtex'],
+    classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
+    license='Public Domain'
+)


### PR DESCRIPTION
Hi,

I thought it would be easier to install if it had a setup.py (it wasn't clear for me where pelican_bibtex.py should be dropped). On top of that it would be great if you could upload it to the PYPI :-)
