### PR TITLE
ENH: include DOI in output of add_publications()

### DIFF
--- a/pelican_bibtex.py
+++ b/pelican_bibtex.py
@@ -79,12 +79,15 @@ def add_publications(generator):
         bibdata_this = BibliographyData(entries={key: entry})
         Writer().write_stream(bibdata_this, bib_buf)
         text = formatted_entry.text.render(html_backend)
+        doi = entry.fields.get('doi') if 'doi' in entry.fields.keys() else ""
+        url = entry.fields.get('url') if 'url' in entry.fields.keys() else ""
 
         publications.append((key,
                              year,
                              text,
                              bib_buf.getvalue(),
-                             entry.fields['doi'],
+                             doi,
+                             url,
                              pdf,
                              slides,
                              poster))

--- a/pelican_bibtex.py
+++ b/pelican_bibtex.py
@@ -84,6 +84,7 @@ def add_publications(generator):
                              year,
                              text,
                              bib_buf.getvalue(),
+                             entry.fields['doi'],
                              pdf,
                              slides,
                              poster))


### PR DESCRIPTION
for creating links to publications inside Jinja templates, it's extremely helpful to have the document's DOI at hand.
