### PR TITLE
Allow for latex encoding

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -48,9 +48,9 @@ if your bibtex file is contains latex symbols
 
 
 If the file is present and readable, you will be able to find the `publications`
-variable in all templates.  It is a list of tuples with the following fields:
+variable in all templates.  It is a list of dictionaries with the following keys:
 ```
-(key, year, text, bibtex, pdf, slides, poster)
+key, year, text, bibtex, pdf, slides, poster
 ```
 
 1. `key` is the BibTeX key (identifier) of the entry.
@@ -100,14 +100,19 @@ using `forceescape`.
 <section id="content" class="body">
     <h1 class="entry-title">Publications</h1>
     <ul>
-    {% for key, year, text, bibtex, pdf, slides, poster in publications %}
-    <li id="{{ key }}">{{ text }}
-    [&nbsp;<a href="javascript:disp('{{ bibtex|replace('\n', '\\n')|escape|forceescape }}');">Bibtex</a>&nbsp;]
-    {% for label, target in [('PDF', pdf), ('Slides', slides), ('Poster', poster)] %}
-    {{ "[&nbsp;<a href=\"%s\">%s</a>&nbsp;]" % (target, label) if target }}
-    {% endfor %}
-    </li>
-    {% endfor %}
+      {% for group in publications|groupby('year')|reverse %}
+      <li> {{group.grouper}}
+        <ul>
+        {% for publication in group.list %}
+          <li id="{{ publication.key }}">{{ publication.text }}
+          [&nbsp;<a href="javascript:disp('{{ publication.bibtex|replace('\n', '\\n')|escape|forceescape }}');">Bibtex</a>&nbsp;]
+          {% for label, target in [('PDF', publication.pdf), ('Slides', publication.slides), ('Poster', publication.poster)] %}
+            {{ "[&nbsp;<a href=\"%s\">%s</a>&nbsp;]" % (target, label) if target }}
+          {% endfor %}
+          </li>
+        {% endfor %}
+        </ul></li>
+      {% endfor %}
     </ul>
 </section>
 {% endblock %}

--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,11 @@ Requirements
 pip install pybtex
 ```
 
+and optionally `latexcodec` if you want to use a latex encoded bibtex
+```bash
+pip install latexcodec
+```
+
 How to Use
 ==========
 
@@ -33,6 +38,14 @@ Configuration is simply:
 ```python
 PUBLICATIONS_SRC = 'content/pubs.bib'
 ```
+
+And optionally
+
+```python
+PUBLICATIONS_ENCODING = 'latex'
+```
+if your bibtex file is contains latex symbols
+
 
 If the file is present and readable, you will be able to find the `publications`
 variable in all templates.  It is a list of tuples with the following fields:

--- a/Readme.md
+++ b/Readme.md
@@ -113,6 +113,13 @@ using `forceescape`.
 {% endblock %}
 ```
 
+When using the `latex` encoding you might want to add some replace to remove the extra curly brackets in
+```python
+<li id="{{ key }}">{{ text | replace('{', '') | replace('}','') }}
+```
+
+
+
 Extending this plugin
 =====================
 

--- a/pelican_bibtex.py
+++ b/pelican_bibtex.py
@@ -96,13 +96,13 @@ def add_publications(generator):
         Writer().write_stream(bibdata_this, bib_buf)
         text = formatted_entry.text.render(html_backend)
 
-        publications.append((key,
-                             year,
-                             text,
-                             bib_buf.getvalue(),
-                             pdf,
-                             slides,
-                             poster))
+        publications.append({'key': key,
+                             'year': year,
+                             'text': text,
+                             'bibtex': bib_buf.getvalue(),
+                             'pdf': pdf,
+                             'slides': slides,
+                             'poster': poster})
 
     generator.context['publications'] = publications
 

--- a/pelican_bibtex.py
+++ b/pelican_bibtex.py
@@ -46,13 +46,27 @@ def add_publications(generator):
         from pybtex.database import BibliographyData, PybtexError
         from pybtex.backends import html
         from pybtex.style.formatting import plain
+
     except ImportError:
         logger.warn('`pelican_bibtex` failed to load dependency `pybtex`')
         return
 
     refs_file = generator.settings['PUBLICATIONS_SRC']
+
+    if 'PUBLICATIONS_ENCODING' in generator.settings:
+        encoding = generator.settings['PUBLICATIONS_ENCODING']
+    else:
+        encoding = None
+
+    if encoding == "latex":
+        try:
+            import latexcodec
+        except ImportError:
+            logger.warn('`pelican_bibtex` failed to load dependency `codecs` and `latexcodec`')
+            return
+
     try:
-        bibdata_all = Parser().parse_file(refs_file)
+        bibdata_all = Parser(encoding=encoding).parse_file(refs_file)
     except PybtexError as e:
         logger.warn('`pelican_bibtex` failed to parse file %s: %s' % (
             refs_file,


### PR DESCRIPTION
A quick hack to allow for latex encoding when reading bibtex files. This will replace the latex commands when parsing the bib file.  Need to set up a new configuration key PUBLICATIONS_ENCODING
