### PR TITLE
Split by bibtex field

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,6 +59,29 @@ This plugin will take all defined fields and make them available in the template
 If a field is not defined, the tuple field will be `None`.  Furthermore, the
 fields are stripped from the generated BibTeX (found in the `bibtex` field).
 
+Split into lists of publications
+--------------------------------
+
+You can add an extra field to each bibtex entry. This field has a value as a comma seperated list.
+These values are the keys of lists containing the associated bibtex entries.
+
+For example, if you want to associate an entry with two different tags (foo-tag, bar-tag), 
+you add the following field to the bib entry:
+
+```
+@article{
+   foo13
+   ...
+   tags = {foo-tag, bar-tag}
+}
+```
+
+You'll need to set `PUBLICATIONS_SPLIT_BY = tags` in your `pelicanconf.py`. In your template 
+(see below), you can then access these lists with the variables `publications_lists['foo-tag']` 
+and `publications_lists['bar-tag']`
+
+With `PUBLICATIONS_UNTAGGED_TITLE = 'others'` you can assign all untagged entries 
+to the variable `publications_lists['others']`.
 
 Template Example
 ================
@@ -98,6 +121,40 @@ using `forceescape`.
     </ul>
 </section>
 {% endblock %}
+```
+
+Using lists of publications
+---------------------------
+
+The variable `publications_lists` is a map with the keys being the comma seperated entries of the field
+defined in `PUBLICATIONS_SPLIT_BY`. You can replace `publications` from the previous example with
+`publications_lists['foo-tag']` to only show the publications with the tag `foo-tag`. You can also iterate
+over the map and present all bib entries of each list:
+
+The section of the previous example changes to:
+
+```python
+...
+<section id="content" class="body">
+    <h1 class="entry-title">Publications</h1>
+
+	{% for tag in publications_lists %}
+	   {% if publications_lists|length > 1 %}
+        		<h2>{{tag}}</h2>
+	   {% endif %}
+	   <ul>
+	    {% for key, year, text, bibtex, pdf, slides, poster in  publications_lists[tag] %}
+	    <li id="{{ key }}">{{ text }}
+	    [&nbsp;<a href="javascript:disp('{{ bibtex|replace('\n', '\\n')|escape|forceescape }}');">Bibtex</a>&nbsp;]
+	    {% for label, target in [('PDF', pdf), ('Slides', slides), ('Poster', poster)] %}
+	    {{ "[&nbsp;<a href=\"%s\">%s</a>&nbsp;]" % (target, label) if target }}
+	    {% endfor %}
+	    </li>
+	    {% endfor %}
+	   </ul>
+	{% endfor %}
+</section>
+...
 ```
 
 Extending this plugin

--- a/Readme.md
+++ b/Readme.md
@@ -76,7 +76,7 @@ you add the following field to the bib entry:
 }
 ```
 
-You'll need to set `PUBLICATIONS_SPLIT_BY = tags` in your `pelicanconf.py`. In your template 
+You'll need to set `PUBLICATIONS_SPLIT_BY = 'tags'` in your `pelicanconf.py`. In your template 
 (see below), you can then access these lists with the variables `publications_lists['foo-tag']` 
 and `publications_lists['bar-tag']`
 
@@ -128,9 +128,9 @@ Using lists of publications
 
 The variable `publications_lists` is a map with the keys being the comma seperated entries of the field
 defined in `PUBLICATIONS_SPLIT_BY`. You can replace `publications` from the previous example with
-`publications_lists['foo-tag']` to only show the publications with the tag `foo-tag`. You can also iterate
-over the map and present all bib entries of each list:
+`publications_lists['foo-tag']` to only show the publications with the tag `foo-tag`. 
 
+You can also iterate over the map and present all bib entries of each list. 
 The section of the previous example changes to:
 
 ```python

--- a/pelican_bibtex.py
+++ b/pelican_bibtex.py
@@ -47,7 +47,8 @@ def add_publications(generator):
         Flag whether or not publications should be splitted
 
     generator.context['publications']:
-        (Deprecated) List of tuples (key, year, text, bibtex, pdf, slides, poster).
+        Contains all publications as a list of tuples
+        (key, year, text, bibtex, pdf, slides, poster).
         See Readme.md for more details.
     """
     if 'PUBLICATIONS_SRC' not in generator.settings:
@@ -75,7 +76,8 @@ def add_publications(generator):
             str(e)))
         return
 
-    publications_lists = {'all' : []}
+    publications = []
+    publications_lists = {}
     publications_untagged = []
 
     split_by = None
@@ -127,7 +129,7 @@ def add_publications(generator):
         entry_tuple = (key, year, text, bib_buf.getvalue(),
                        pdf, slides, poster)
 
-        publications_lists['all'].append(entry_tuple)
+        publications.append(entry_tuple)
 
         for tag in tags:
             publications_lists[tag].append(entry_tuple)
@@ -139,16 +141,10 @@ def add_publications(generator):
     if untagged_title and publications_untagged:
         publications_lists[untagged_title] = publications_untagged
 
-    # for backward compatibility to 0.2.1
-    generator.context['publications'] = publications_lists['all']
 
-    if split_by:
-        del publications_lists['all']
-        generator.context['publications_lists'] = publications_lists
-        generator.context['split'] = True
-    else:
-        generator.context['publications_lists'] = publications_lists
-        generator.context['split'] = False
+    # output
+    generator.context['publications'] = publications
+    generator.context['publications_lists'] = publications_lists
 
 
 

--- a/pelican_bibtex.py
+++ b/pelican_bibtex.py
@@ -43,9 +43,6 @@ def add_publications(generator):
         Values are lists of tuples (key, year, text, bibtex, pdf, slides, poster)
         See Readme.md for more details.
 
-    generator.context['split']:
-        Flag whether or not publications should be splitted
-
     generator.context['publications']:
         Contains all publications as a list of tuples
         (key, year, text, bibtex, pdf, slides, poster).
@@ -109,7 +106,6 @@ def add_publications(generator):
             tags = entry.fields.get(split_by, None)
 
             # parse to list, and trim each string
-            # tags = tags.strip()
             if tags:
                 tags = tags.split(",")
                 tags = list(map(str.strip, tags))

--- a/pelican_bibtex.py
+++ b/pelican_bibtex.py
@@ -101,19 +101,18 @@ def add_publications(generator):
         slides = entry.fields.get('slides', None)
         poster = entry.fields.get('poster', None)
 
-        tags = []
         if split_by:
-            tags = entry.fields.get(split_by, None)
+            tags = entry.fields.get(split_by, [])
 
             # parse to list, and trim each string
             if tags:
                 tags = tags.split(",")
                 tags = list(map(str.strip, tags))
 
-            # create keys in publications_lists if at least one
-            # tag is given
-            for tag in tags:
-                publications_lists[tag] = publications_lists.get(tag, [])
+                # create keys in publications_lists if at least one
+                # tag is given
+                for tag in tags:
+                    publications_lists[tag] = publications_lists.get(tag, [])
 
 
         #render the bibtex string for the entry

--- a/pelican_bibtex.py
+++ b/pelican_bibtex.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 from pelican import signals
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 
 def add_publications(generator):


### PR DESCRIPTION
I personally maintain most bibtex libraries with jabref. Jabref allows for grouping your entries by some comma separated entry in your bibtex file: http://help.jabref.org/en/Groups

This pull request presents a solution to use a custom bibtex field (e.g. tags) and create a dictionary of dictionaries of publications which specify the key in the custom field. The name is `publications_lists`.

First step is to specify the bibtex field in `PUBLICATIONS_SPLIT_BY` to create a dictionary holding the lists of publications.

For example, if you use `tags` as your custom field to group items in jabref:

```
@article{
   foo13
   ...
   tags = {foo-tag, bar-tag}
}
```
... you set `PUBLICATIONS_SPLIT_BY = 'tags'` in your `pelicanconf.py`. You can then access in the template all publications with the tag `foo-tag` with `publications_lists['foo-tag']`.

If you want to have a list with untagged publications, you need to provide a title for that (which is the key of that list). For example, setting `PUBLICATIONS_UNTAGGED_TITLE='others'` in your `pelicanconf.py` will create a list `publications_lists['others']` with all publications without a tag.

The presented PR is backward compatible to older versions, e.g. 0.2.1, in that sense that all publications are still provided with the list `publications`.